### PR TITLE
minor: Added app version on login screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Continuous Integration](https://github.com/1jamesthompson1/TAIC-smart-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/1jamesthompson1/TAIC-smart-tools/actions/workflows/ci.yml)
-![Version](https://img.shields.io/badge/Version-0.6.3-blue)
+![Version](https://img.shields.io/badge/Version-0.7.0-blue)
 
 ## Preview
 

--- a/app.py
+++ b/app.py
@@ -1363,6 +1363,7 @@ with gr.Blocks(
 ) as login_page:
     with gr.Column(elem_classes="complete-center"):
         gr.Markdown("# TAIC smart tools")
+        gr.Markdown(f"**App version:** {Version.CURRENT_VERSION}")
         gr.Markdown("Please login to continue:")
         gr.Button("Login", link="/login")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "TAIC_smart_tools"
-version = "0.6.3"
+version = "0.7.0"
 description = "An app that provides access to smart tools mainly a RAG agent which is built off a dataset of TAIC, ATSB and TSB reports to assist investigators and researchers."
 authors = [{ name = "James Thompson", email = "1jamesthompson1@gmail.com" }]
 requires-python = ">=3.10,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -2952,7 +2952,7 @@ full = [
 
 [[package]]
 name = "taic-smart-tools"
-version = "0.6.3"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Added the app version on the login screen.

Did not add any other information on the login screen, as at this stage, the individual has not logged in and could be an unauthorised person.

In the absence of design specification, made a minimal change that seemed to bay logical regarding the existing layout of the login page.

Edited the label to "App version:" (from just "App:" once logged in) to clarify the meaning of the following number. There is sufficient estate on the login page for that. Another option would have been to use the label "Version:". We may want to consider applying consistent labeling across the different pages.