### PR TITLE
patch: Updated conversation title

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Continuous Integration](https://github.com/1jamesthompson1/TAIC-smart-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/1jamesthompson1/TAIC-smart-tools/actions/workflows/ci.yml)
-![Version](https://img.shields.io/badge/Version-0.7.0-blue)
+![Version](https://img.shields.io/badge/Version-0.7.1-blue)
 
 ## Preview
 

--- a/app.py
+++ b/app.py
@@ -1348,7 +1348,7 @@ app = gr.mount_gradio_app(
     app,
     smart_tools,
     path="/tools",
-    auth_dependency=get_user,
+    auth_dependency=lambda request: get_user(request),  # noqa: RUF100
     show_api=False,
 )
 

--- a/app.py
+++ b/app.py
@@ -1348,7 +1348,7 @@ app = gr.mount_gradio_app(
     app,
     smart_tools,
     path="/tools",
-    auth_dependency=lambda request: get_user(request),  # noqa: RUF100
+    auth_dependency=lambda request: get_user(request),  # noqa: PLW0108, RUF100
     show_api=False,
 )
 

--- a/app.py
+++ b/app.py
@@ -1348,7 +1348,7 @@ app = gr.mount_gradio_app(
     app,
     smart_tools,
     path="/tools",
-    auth_dependency=lambda request: get_user(request),
+    auth_dependency=get_user,
     show_api=False,
 )
 

--- a/backend/Assistant.py
+++ b/backend/Assistant.py
@@ -416,7 +416,7 @@ class Assistant:
         if len(msg) > conversation_context_length:
             msg = msg[-conversation_context_length:]
 
-        return (
+        title = (
             self.openai_client.responses.create(
                 model="gpt-5-mini",
                 instructions=AssistantPrompts.conversation_title(),
@@ -424,6 +424,13 @@ class Assistant:
                 store=False,
             ).output_text
         ).strip()
+
+        # If for some reason the AI returns a long title, truncates it
+        max_len = 100
+        if len(title) > max_len:
+            title = title[: max_len - 3] + "..."
+
+        return title
 
     def complete_tool_use(
         self,

--- a/backend/Assistant.py
+++ b/backend/Assistant.py
@@ -401,18 +401,12 @@ class Assistant:
             msg = msg[-conversation_context_length:]
 
         return (
-            self.openai_client.chat.completions.create(
+            self.openai_client.responses.create(
                 model="gpt-4.1-nano",
-                messages=[
-                    {
-                        "role": "system",
-                        "content": AssistantPrompts.conversation_title(),
-                    },
-                    *msg,
-                ],
-            )
-            .choices[0]
-            .message.content
+                instructions=AssistantPrompts.conversation_title(),
+                input=msg,
+                store=False,
+            ).output_text
         ).strip()
 
     def complete_tool_use(

--- a/backend/Assistant.py
+++ b/backend/Assistant.py
@@ -283,8 +283,8 @@ class AssistantPrompts:
     @staticmethod
     def conversation_title():
         return """
-You are part of a chatbot assistant at the Transport Accident Investigation Commission that help users add titles to their conversation. You will receive the conversation and you are too response with a 5 word summary of the conversation.
-Provide a title that will best help the user identify what conversation it was.
+You are part of a chatbot assistant at the Transport Accident Investigation Commission. You help users add titles to their conversation. You will receive the conversation and you are to respond with a 5 word summary of the conversation.
+Provide a title that will best help the user recall what the conversation was.
 Just respond with the title and nothing else.
         """
 

--- a/backend/Assistant.py
+++ b/backend/Assistant.py
@@ -407,7 +407,7 @@ class Assistant:
 
         # Clear history to only include the last 5 user or assistant messages, no system messages or tool calls
         msg = [
-            m["display"]
+            m["display"]["role"] + ": " + m["display"]["content"]
             for m in history
             if m["display"]["role"] in ["user", "assistant"]
             and m["display"].get("metadata") is None
@@ -420,7 +420,7 @@ class Assistant:
             self.openai_client.responses.create(
                 model="gpt-5-mini",
                 instructions=AssistantPrompts.conversation_title(),
-                input=msg,
+                input=f"Here is the last {conversation_context_length} messages from the conversation history: {msg}. Can you please provide a title to help?",
                 store=False,
             ).output_text
         ).strip()

--- a/backend/Assistant.py
+++ b/backend/Assistant.py
@@ -38,8 +38,8 @@ class CompleteHistory(list):
 
     def format(self):
         """
-        Pre to 0.3.0 the message was justa  list of dict with "role", "content" and optional "metadata".
-        Need to expand this out into the full format with "display" and "ai" keys. TO do this just copy the message to both and only have role and content for the ai key.
+        Pre to 0.3.0 the message was just a list of dict with "role", "content" and optional "metadata".
+        Need to expand this out into the full format with "display" and "ai" keys. To do this just copy the message to both and only have role and content for the ai key.
         """
         new_history = []
 

--- a/backend/Assistant.py
+++ b/backend/Assistant.py
@@ -282,6 +282,9 @@ class AssistantPrompts:
 
     @staticmethod
     def conversation_title():
+        """
+        Returns AI prompt to generate a short title that summarises the topic of the conversation
+        """
         return """
 You are part of a chatbot assistant at the Transport Accident Investigation Commission. You help users add titles to their conversation. You will receive the conversation and you are to respond with a 5 word summary of the conversation.
 Provide a title that will best help the user recall what the conversation was.
@@ -290,6 +293,9 @@ Just respond with the title and nothing else.
 
     @staticmethod
     def general_info(columns, rows, last_updated):
+        """
+        Returns general context of the user's query
+        """
         return f"""
 Below is general information to help you contextualise the user's query.
 
@@ -325,6 +331,9 @@ issues.
 
     @staticmethod
     def orient_plan_system(general_info):
+        """
+        Returns AI prompt to orient and plan the initial orient and plan analysis
+        """
         return f"""
 You are a expert working at the New Zealand transport accident investigation commission. Your job is to assistant employees of TAIC with their queries. The day is {datetime.now(timezone.utc)}. You should respond as if you are a senior accident investigator/research who is speaking to your colleagues.
 
@@ -336,6 +345,9 @@ You will be provided the conversation history including any function calls and o
 
     @staticmethod
     def act_system(general_info):
+        """
+        Returns AI prompt to generate the response to the prompt
+        """
         return f"""
 You are a expert working at the New Zealand transport accident investigation commission. Your job is to assistant employees of TAIC with their queries. The day is {datetime.now(timezone.utc)}. You should respond as if you are a senior accident investigator/research who is speaking to your colleagues. Keep your responses short and to the point.
 
@@ -349,6 +361,10 @@ If you choose to respond to the user, ensure you provide a concise and accurate 
 
 
 class Assistant:
+    """
+    Assistant class handles the chat conversation and AI calls.
+    """
+
     def __init__(
         self,
         searcher,

--- a/backend/Assistant.py
+++ b/backend/Assistant.py
@@ -402,7 +402,7 @@ class Assistant:
 
         return (
             self.openai_client.responses.create(
-                model="gpt-4.1-nano",
+                model="gpt-5-mini",
                 instructions=AssistantPrompts.conversation_title(),
                 input=msg,
                 store=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "TAIC_smart_tools"
-version = "0.7.0"
+version = "0.7.1"
 description = "An app that provides access to smart tools mainly a RAG agent which is built off a dataset of TAIC, ATSB and TSB reports to assist investigators and researchers."
 authors = [{ name = "James Thompson", email = "1jamesthompson1@gmail.com" }]
 requires-python = ">=3.10,<3.13"

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -116,11 +116,10 @@ def test_conversation_title_generation(mock_assistant):
     history.add_message("assistant", "Aviation safety is...")
 
     # Mock OpenAI response for title generation
-    with patch.object(mock_assistant.openai_client, "chat") as mock_chat:
+    with patch.object(mock_assistant.openai_client, "responses") as mock_responses:
         mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message.content = "Aviation Safety Discussion"
-        mock_chat.completions.create.return_value = mock_response
+        mock_response.output_text = "Aviation Safety Discussion"
+        mock_responses.create.return_value = mock_response
 
         title = mock_assistant.provide_conversation_title(history)
         assert isinstance(title, str)

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -114,16 +114,18 @@ def test_conversation_title_generation(mock_assistant):
     history = CompleteHistory([])
     history.add_message("user", "Tell me about aviation safety")
     history.add_message("assistant", "Aviation safety is...")
+    max_len = 100
 
     # Mock OpenAI response for title generation
     with patch.object(mock_assistant.openai_client, "responses") as mock_responses:
         mock_response = Mock()
-        mock_response.output_text = "Aviation Safety Discussion"
+        mock_response.output_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna."
         mock_responses.create.return_value = mock_response
 
         title = mock_assistant.provide_conversation_title(history)
         assert isinstance(title, str)
         assert len(title) > 0
+        assert len(title) <= max_len
 
 
 def test_history_format_validation():

--- a/uv.lock
+++ b/uv.lock
@@ -2952,7 +2952,7 @@ full = [
 
 [[package]]
 name = "taic-smart-tools"
-version = "0.7.0"
+version = "0.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Worked on the conversation title:
- **Assistant.Provide_conversation_title**
  - Changed Open AI API call from 'chat completion' to 'responses'
  - Changed model from gpt-4.1-nano to gpt-5-mini
- **AssistantPrompts.conversation_title**
  - Fixed typos and tweaked the wording
- **CompleteHistory.format**
  - Fixed typos in text

The change to the response API appears to have fixed the issue with long conversations (in terms of size of the content, e.g. tables) where the conversation title was the same as the last response of the AI chat instead of a five-word summary.
This is possibly thanks to the `instructions` parameter, that provides the instruction separately from the next instructions included in the conversation, and therefore prevents mixing up the initial instruction with the last instruction from the conversation.